### PR TITLE
Fix malformed bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "fonts/roboto/Roboto-Regular.woff2",
     "fonts/roboto/Roboto-Thin.ttf",
     "fonts/roboto/Roboto-Thin.woff",
-    "fonts/roboto/Roboto-Thin.woff2",
+    "fonts/roboto/Roboto-Thin.woff2"
   ],
   "ignore": [
     "jade/",


### PR DESCRIPTION
Bower throws an `EMALFORMED` when attempting to install recent materialize SHAs (i.e., `ffb9783b388912fbe1245a1362f0b1ace03d46bd`).
